### PR TITLE
Update create-signed-cert.ps1

### DIFF
--- a/eks-deployments/webhook/create-signed-cert.ps1
+++ b/eks-deployments/webhook/create-signed-cert.ps1
@@ -161,10 +161,10 @@ Write-Verbose 'Writing signed certificate'
 Invoke-Expression -Command "Write-Output `"$serverCertificate`" | openssl base64 -d -A -out `"$serverCertificateFilePath`""
 
 Write-Verbose 'Creating secret with CA certificate and server certificate'
-$cmd = "kubectl create secret generic $SecretName " + `
+$cmd = "kubectl -n $Namespace create secret generic $SecretName " + `
             "--from-file=key.pem=`"$serverCertificateKeyFilePath`" " + `
             "--from-file=cert.pem=`"$serverCertificateFilePath`" " + `
-            "--dry-run=client -o yaml | " + `
+            "-o yaml | " + `
                 "kubectl -n $Namespace apply -f -"
 Write-Verbose $cmd
 Invoke-Expression -Command $cmd


### PR DESCRIPTION
Due to kubectl version 1.14+, user will encounter error. Therefore, removed --dry-run

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
