### PR TITLE
Fix deprecated keyword and warning message redirection to support 1.18/1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains cloudformation templates, powershell scripts, kubernetes deployment configurations and sample applications required to set up AWS managed Active Directory and gMSA account setup to demonstrate gMSA end-to-end workflow with Amazon Elastic Kubernetes Services (EKS) cluster.
 
-NOTE: gMSA functionality has been validated on EKS v1.14 master with v1.14 worker nodes, v1.16. EKS master with v1.16 worker nodes, v1.17 EKS master with v1.16 & v1.17 worker nodes. v1.15 is pending validation.
+NOTE: gMSA functionality has been validated on v1.16 EKS master with v1.16 worker nodes, v1.17 EKS master with v1.16 & v1.17 worker nodes, v1.18 EKS master with v1.18 worker nodes, and v1.19 EKS master with v1.19 worker nodes.
 
 # Prerequisites
 * AWS CLI

--- a/eks-deployments/README.md
+++ b/eks-deployments/README.md
@@ -28,6 +28,8 @@ aws ssm list-command-invocations --filter key=DocumentName,value=$domainjoinSSMd
 # If the group doesn't exist, it'll create a new one and then adds the instance to that AD group.
 # You can execute the ssmdomain join document on-demand on that instnace id.
 # To retry on failed instance (replace XXXXX with failed instance id)
+# If you follow the step "Create and join gMSA AD security group", the instance will be joined to the domain already.
+# Here you will be seeing an error "Cannot add computer XXXXX to domain 'gmsa.blog.corp.com' because it is already in that domain.", which is expected. Ignore the error and continue.
 $commandId = aws ssm send-command --document-name $domainjoinSSMdoc --targets "Key=InstanceIds, Values=XXXXX" --query "Command.CommandId" --output text
 
 aws ssm list-command-invocations --command-id $commandId

--- a/eks-deployments/instance-domain-join.md
+++ b/eks-deployments/instance-domain-join.md
@@ -45,7 +45,7 @@ aws ssm create-association --name $domainjoinSSMdoc --document-version 1 --targe
 aws ssm list-associations --association-filter-list "key=Name, value=$domainjoinSSMdoc"
 ```
 
-## 4. Create and join gMSA AD security group (Optional)
+## 4. Create and join gMSA AD security group
 *If the AD security group exists already prior to domain join, the worker instance will be added to that security group during domain join. Otherwise, you need to execute this document to create and join AD. AD security group creation shouldn't be executed concurrently. Concurrent execution will result into duplicate AD group creation. Hence this needs to be run one instance at a time. This SSM document shoudn't be attached to autoscaling group*
 
 ```powershell

--- a/eks-deployments/instance-domain-join.md
+++ b/eks-deployments/instance-domain-join.md
@@ -45,7 +45,7 @@ aws ssm create-association --name $domainjoinSSMdoc --document-version 1 --targe
 aws ssm list-associations --association-filter-list "key=Name, value=$domainjoinSSMdoc"
 ```
 
-## 4. Create and join gMSA AD security group
+## 4. Create and join gMSA AD security group (Optional)
 *If the AD security group exists already prior to domain join, the worker instance will be added to that security group during domain join. Otherwise, you need to execute this document to create and join AD. AD security group creation shouldn't be executed concurrently. Concurrent execution will result into duplicate AD group creation. Hence this needs to be run one instance at a time. This SSM document shoudn't be attached to autoscaling group*
 
 ```powershell

--- a/eks-deployments/instance-domain-join.md
+++ b/eks-deployments/instance-domain-join.md
@@ -1,17 +1,7 @@
 # EKS Windows Worker changes
 This document gives list of steps to enable gMSA feature-gates and to attach to domain join SSM document.
 
-## 1. Launch EKS Windows worker instances with gMSA feature-gates
-*gMSA is an alpha feature in Kubernetes 1.14. For details refer [here](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)*
-*For alpha features we need to enable the feature-gates.* 
-
-```powershell
-# In EKS Windows worker CloudFormation stack, paste the following argument
-BootstrapArguments: --feature-gates="WindowsGMSA=true"
-```
-
-*gMSA is a beta feature in Kubernetes 1.16 and stable from Kubernetes 1.18 onwards. Hence, the feature flag is enabled by default from 1.16 onwards, so the above step is not required for 1.16 onwards.* 
-
+## 1. Launch EKS Windows worker instances
 ```powershell
 ##### ACTION REQUIRED - START #####
 $eksWindowsStack = "xxxxx" # Name of the Cloudformation stack that created EKS Windows worker nodes.

--- a/eks-deployments/patch-coredns/Patch-Coredns.ps1
+++ b/eks-deployments/patch-coredns/Patch-Coredns.ps1
@@ -55,20 +55,21 @@ if (!(Get-Command -Name 'kubectl' -ErrorAction:SilentlyContinue)) {
     throw 'kubectl not found'
 }
 
-[string]$clusterVersionInfo = Invoke-Expression -Command "kubectl version --short=true -o json" 
-$clusterVersionObj = ConvertFrom-Json -InputObject $clusterVersionInfo
-[string]$serverVersion = $clusterVersionObj.serverVersion.gitVersion
+$cmd = 'kubectl version --short=true -o json'
+[string]$ret = Invoke-Expression -Command $cmd
+$clusterVersionObj = ConvertFrom-Json -InputObject $ret
+$serverVersion = $clusterVersionObj.serverVersion.minor
 
-#The keyword 'upstream' is decprecated starting from Kubernetes 1.18
-$UpstreamKey = 'upstream'
-if ($serverVersion -ge "v1.18") {
-    $UpstreamKey = ''
+# The keyword 'upstream' is decprecated starting from Kubernetes 1.18
+$upstreamKey = 'upstream'
+if ($serverVersion -ge 18) {
+    $upstreamKey = ''
 }
 
 $patchContent = (Get-Content -Path $CorednsTemplateConfig) | ForEach-Object {
     $_ -replace '\${ACTIVEDIRECTORYDNS}', $ActiveDirectoryDNS `
        -replace '\${DNSSERVERIPS}', $DNSServerIPs `
-       -replace '\${UPSTREAM}', $UpstreamKey
+       -replace '\${UPSTREAM}', $upstreamKey
 }
 
 $tempFile = [System.IO.Path]::Combine($PSScriptRoot, "patch.yaml")

--- a/eks-deployments/patch-coredns/README.md
+++ b/eks-deployments/patch-coredns/README.md
@@ -22,8 +22,8 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
         pods insecure
-        #Note that the keyword "upstream" is deprecated starting from Kubernetes 1.18,
-        #refer to https://github.com/aws/containers-roadmap/issues/1115 for more detail
+        # Note that the keyword "upstream" is deprecated starting from Kubernetes 1.18,
+        # refer to https://github.com/aws/containers-roadmap/issues/1115 for more detail
         upstream
         fallthrough in-addr.arpa ip6.arpa
         }

--- a/eks-deployments/patch-coredns/README.md
+++ b/eks-deployments/patch-coredns/README.md
@@ -22,6 +22,8 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
         pods insecure
+        #Note that the keyword "upstream" is deprecated starting from Kubernetes 1.18,
+        #refer to https://github.com/aws/containers-roadmap/issues/1115 for more detail
         upstream
         fallthrough in-addr.arpa ip6.arpa
         }

--- a/eks-deployments/patch-coredns/patch-coredns-template.yaml
+++ b/eks-deployments/patch-coredns/patch-coredns-template.yaml
@@ -28,7 +28,7 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
         pods insecure
-        upstream
+        ${UPSTREAM}
         fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153

--- a/eks-deployments/webhook/gmsa-webhook-template.yaml
+++ b/eks-deployments/webhook/gmsa-webhook-template.yaml
@@ -76,7 +76,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: ${NAME}
-        image: wk88/k8s-gmsa-webhook:${WEBHOOKIMAGE}
+        image: wk88/k8s-gmsa-webhook:latest
         imagePullPolicy: IfNotPresent
         readinessProbe:
           httpGet:

--- a/eks-deployments/webhook/patch-webhook-template.ps1
+++ b/eks-deployments/webhook/patch-webhook-template.ps1
@@ -48,24 +48,12 @@ $kubeConfig = ConvertFrom-Json -InputObject $ret
 $clusterConfig = $kubeConfig.clusters[0].cluster
 $CaBundle = $clusterConfig."certificate-authority-data"
 
-# Get the Server's Kubernetes Version
-$cmd = 'kubectl version --short=true -o json'
-[string]$ret = Invoke-Expression -Command $cmd
-$fullVersion = ConvertFrom-Json -InputObject $ret
-$serverVersion = $fullVersion.serverVersion.minor
-
-$webhookVersion = 'latest'
-if ($serverVersion -lt 16) {
-    $webhookVersion='v1.14'
-}
-
 Write-Verbose 'Constructing new deployment YAML content'
 $newTemplate = (Get-Content -Path $DeploymentTemplateFilePath) | ForEach-Object {
     $_ -replace '\${CA_BUNDLE}', $CaBundle `
        -replace '\${NAME}', $ServiceName `
        -replace '\${SECRETNAME}', $SecretName `
-       -replace '\${NAMESPACE}', $Namespace `
-       -replace '\${WEBHOOKIMAGE}', $webhookVersion
+       -replace '\${NAMESPACE}', $Namespace
 }
 
 Write-Verbose ('Updating deployment YAML: {0}' -f $OutputFilePath)


### PR DESCRIPTION
*Issue #, if available:*
1. In the coredns template file, a key word 'upstream' has been deprecated starting from Kubernetes 1.18
2. Starting from Kubernetes 1.19, warning messages from kubectl will be printed out by default. There is a bug that kubectl flags one of the warning messages as an error message, which interrupts the webhook deployment script.

*Description of changes:*
1. Modified the original static string 'upstream' as a place holder, checking the Kubernetes version in the script to determine the value.
2. Filtered the 'Warning' keyword before redirecting the output, so that it won't be treated as an error. Other error messages will still be detected. Also after done creating the webhook, adding validation section to verify that both mutating and validating webhooks are installed correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
