### PR TITLE
Fixed deprecated keyword and warning message redirection issue to support 1.18/1.19, updated instructions accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This repository contains cloudformation templates, powershell scripts, kubernetes deployment configurations and sample applications required to set up AWS managed Active Directory and gMSA account setup to demonstrate gMSA end-to-end workflow with Amazon Elastic Kubernetes Services (EKS) cluster.
 
-NOTE: gMSA functionality has been validated on EKS v1.14 master with v1.14 worker nodes, v1.16. EKS master with v1.16 worker nodes, v1.17 EKS master with v1.16 & v1.17 worker nodes. v1.15 is pending validation.
-
 # Prerequisites
 * AWS CLI
 * Powershell core

--- a/eks-deployments/README.md
+++ b/eks-deployments/README.md
@@ -26,13 +26,14 @@ aws ssm list-command-invocations --filter key=DocumentName,value=$domainjoinSSMd
 # https://us-west-2.console.aws.amazon.com/systems-manager/run-command/complete-commands?region=us-west-2 
 # One possible failure could be, "Creating new AD security group". This is due to all the EKS Windows instances will concurrently check whether the AD group exists or not. 
 # If the group doesn't exist, it'll create a new one and then adds the instance to that AD group.
-# You can execute the ssmdomain join document on-demand on that instnace id.
+# You can execute the ssmdomain join document on-demand on that instance id.
 # To retry on failed instance (replace XXXXX with failed instance id)
 $commandId = aws ssm send-command --document-name $domainjoinSSMdoc --targets "Key=InstanceIds, Values=XXXXX" --query "Command.CommandId" --output text
 
 aws ssm list-command-invocations --command-id $commandId
 
 # If the failure is in between (Example: joined AD but not part of AD security group), you've to manually fix that based on the error. The easiest way is, terminate the instance and let autoscaling create a new instance.
+# Also the instance might be joined to the domain already, continue with the process if you observe errors similar to "Cannot add computer XXXXX to domain XXXXX because it is already in that domain." in System Manager.
 ##### ACTION REQUIRED - END #####
 
 # Pick an instance to run the SSM command.

--- a/eks-deployments/instance-domain-join.md
+++ b/eks-deployments/instance-domain-join.md
@@ -1,17 +1,7 @@
 # EKS Windows Worker changes
-This document gives list of steps to enable gMSA feature-gates and to attach to domain join SSM document.
+This document gives list of steps to attach to domain join SSM document.
 
-## 1. Launch EKS Windows worker instances with gMSA feature-gates
-*gMSA is an alpha feature in Kubernetes 1.14. For details refer [here](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)*
-*For alpha features we need to enable the feature-gates.* 
-
-```powershell
-# In EKS Windows worker CloudFormation stack, paste the following argument
-BootstrapArguments: --feature-gates="WindowsGMSA=true"
-```
-
-*gMSA is a beta feature in Kubernetes 1.16 and stable from Kubernetes 1.18 onwards. Hence, the feature flag is enabled by default from 1.16 onwards, so the above step is not required for 1.16 onwards.* 
-
+## 1. Launch EKS Windows worker instances
 ```powershell
 ##### ACTION REQUIRED - START #####
 $eksWindowsStack = "xxxxx" # Name of the Cloudformation stack that created EKS Windows worker nodes.

--- a/eks-deployments/patch-coredns/README.md
+++ b/eks-deployments/patch-coredns/README.md
@@ -13,7 +13,7 @@ $directoryName = aws ssm get-parameter --name $directoryNameParam --query "Param
 # Command to verify coredns configmap
 kubectl get configmap coredns -n kube-system -o yaml
 
-# The sample configmap
+# The sample configmap for Kubernetes 1.16 and 1.17
 apiVersion: v1
 data:
   Corefile: |
@@ -37,5 +37,33 @@ data:
 	cache 30 
 	forward . <<DNSServer1>> <<DNSServer2>>
           } 
+kind: ConfigMap
+
+# The sample configmap starting from Kubernetes 1.18
+# Note that the keyword "upstream" is deprecated starting from Kubernetes 1.18,
+# refer to https://github.com/aws/containers-roadmap/issues/1115 for more detail
+apiVersion: v1
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+
+        fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+      cache 30
+      loop
+      reload
+      loadbalance
+    }
+    <<ActiveDirectoryname>>:53 {
+	errors
+	cache 30
+	forward . <<DNSServer1>> <<DNSServer2>>
+          }
 kind: ConfigMap
 ```

--- a/eks-deployments/patch-coredns/patch-coredns-template.yaml
+++ b/eks-deployments/patch-coredns/patch-coredns-template.yaml
@@ -28,7 +28,7 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
         pods insecure
-        upstream
+        ${UPSTREAM}
         fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153

--- a/eks-deployments/webhook/Setup-Webhook.ps1
+++ b/eks-deployments/webhook/Setup-Webhook.ps1
@@ -93,7 +93,7 @@ if (-not (Test-Path -Path $pathTemplateScript)) {
 Invoke-Expression -Command "& '$createCertScript' -ServiceName $ServiceName -SecretName $SecretName -Namespace $Namespace"
 
 # Verify secret
-Invoke-Expression -Command "kubectl get secret -n $Namespace $SecretName" 2>&1
+Invoke-Expression -Command "kubectl get secret -n $Namespace $SecretName" | Select-String -NotMatch "Warning" 2>&1
 
 # Configure webhook and create deployment file
 Invoke-Expression -Command "& '$pathTemplateScript' -DeploymentTemplateFilePath `"$DeploymentTemplate`" -ServiceName `"$ServiceName`" -Namespace `"$Namespace`" -OutputFilePath `"$Outfile`""
@@ -101,5 +101,15 @@ Invoke-Expression -Command "& '$pathTemplateScript' -DeploymentTemplateFilePath 
 if ($DryRun) {
     Write-Output (Get-Content -Path $Outfile)
 } else {
-    Invoke-Expression -Command "kubectl -n $Namespace apply -f `"$Outfile`"" 2>&1
+    Invoke-Expression -Command "kubectl -n $Namespace apply -f `"$Outfile`"" | Select-String -NotMatch "Warning" 2>&1
+
+    # Verify that both mutating and validating webhooks are installed correctly
+    $CmdOutput = Invoke-Expression -Command "kubectl get mutatingwebhookconfigurations $ServiceName"
+    if (($CmdOutput.IndexOf("Error") -ge 0) -or ($CmdOutput.IndexOf("Not Found") -ge 0)) {
+        Write-Output ($CmdOutput)
+    }
+    $CmdOutput = Invoke-Expression -Command "kubectl get validatingwebhookconfigurations $ServiceName"
+    if (($CmdOutput.IndexOf("Error") -ge 0) -or ($CmdOutput.IndexOf("Not Found") -ge 0)) {
+        Write-Output ($CmdOutput)
+    }
 }

--- a/eks-deployments/webhook/gmsa-webhook-template.yaml
+++ b/eks-deployments/webhook/gmsa-webhook-template.yaml
@@ -76,7 +76,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: ${NAME}
-        image: wk88/k8s-gmsa-webhook:${WEBHOOKIMAGE}
+        image: wk88/k8s-gmsa-webhook:latest
         imagePullPolicy: IfNotPresent
         readinessProbe:
           httpGet:

--- a/eks-deployments/webhook/patch-webhook-template.ps1
+++ b/eks-deployments/webhook/patch-webhook-template.ps1
@@ -48,24 +48,12 @@ $kubeConfig = ConvertFrom-Json -InputObject $ret
 $clusterConfig = $kubeConfig.clusters[0].cluster
 $CaBundle = $clusterConfig."certificate-authority-data"
 
-# Get the Server's Kubernetes Version
-$cmd = 'kubectl version --short=true -o json'
-[string]$ret = Invoke-Expression -Command $cmd
-$fullVersion = ConvertFrom-Json -InputObject $ret
-$serverVersion = $fullVersion.serverVersion.minor
-
-$webhookVersion = 'latest'
-if ($serverVersion -lt 16) {
-    $webhookVersion='v1.14'
-}
-
 Write-Verbose 'Constructing new deployment YAML content'
 $newTemplate = (Get-Content -Path $DeploymentTemplateFilePath) | ForEach-Object {
     $_ -replace '\${CA_BUNDLE}', $CaBundle `
        -replace '\${NAME}', $ServiceName `
        -replace '\${SECRETNAME}', $SecretName `
-       -replace '\${NAMESPACE}', $Namespace `
-       -replace '\${WEBHOOKIMAGE}', $webhookVersion
+       -replace '\${NAMESPACE}', $Namespace
 }
 
 Write-Verbose ('Updating deployment YAML: {0}' -f $OutputFilePath)


### PR DESCRIPTION
*Issue #, if available:*
1. In the coredns template file, a key word 'upstream' has been deprecated starting from Kubernetes 1.18.
2. Starting from Kubernetes 1.19, warning messages from kubectl will be printed out by default. There is a bug that kubectl flags one of the warning messages as an error message, which interrupts the webhook deployment script.
3. Kubernetes versions below 1.16 are deprecated.

*Description of changes:*
1. Modified the original static string 'upstream' as a place holder, checking the Kubernetes version in the script to determine the value.
2. Filtered the 'Warning' keyword before redirecting the output, so that it wouldn't be treated as an error. Other error messages would still be detected. Also after done creating the webhook, adding validation section to verify that both mutating and validating webhooks were installed correctly.
3. Kept webook image version as latest since versions below Kubernetes 1.16 were deprecated, also rephrased some of the instructions due to version deprecation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
